### PR TITLE
feat(app): Liminal Hotel desktop (Electron) con botón ‘Host local’ + vertical slice jugable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
-# Liminal-Hotel
+# Liminal Hotel
+
+Prototype vertical slice for the multiplayer horror experience **Liminal Hotel**. This repository bundles the privacy-safe web client, the authoritative WebSocket server, and a desktop hoster built with Electron that can spawn the server locally with a single click.
+
+## Project layout
+
+- `web/liminal-hotel` – Vite-powered web client with microphone loudness capture, lobby UI, and options menu.
+- `server` – Node/TypeScript authoritative server driving Host AI and mic-driven hearing logic.
+- `apps/liminal-hotel-desktop` – Electron wrapper that embeds the client and exposes a **Host local** control to launch the server on an available port.
+
+The repo uses npm workspaces; install once at the root to share dependencies.
+
+```bash
+npm install
+```
+
+## Running the web experience
+
+### Development
+
+```bash
+npm run dev:web
+```
+
+This runs Vite dev mode for the client at <http://localhost:5173>. Use `npm run dev:server` in another terminal to watch the server with hot-reload through `tsx`:
+
+```bash
+npm run dev:server
+```
+
+The lobby’s **Connect** box defaults to `ws://localhost:8787`; adjust the URL if you pick a different port.
+
+### Production build
+
+```bash
+npm run --workspace web/liminal-hotel build
+```
+
+The static output lands in `web/liminal-hotel/dist` and can be hosted on any web server.
+
+## Desktop app with “Host local”
+
+The Electron app embeds the built client and can spawn the Node server as a child process. It auto-selects a free port (starting at `8787`) and broadcasts the LAN URLs back to the UI.
+
+### Develop / preview
+
+```bash
+npm run dev:desktop
+```
+
+This command builds the main & preload scripts, then launches Electron. In development the window loads the Vite dev server if present; otherwise it falls back to the built files under `web/liminal-hotel/dist`.
+
+### Package builds
+
+```bash
+npm run build --workspace server
+npm run build --workspace web/liminal-hotel
+npm run build:desktop
+```
+
+The Electron builder configuration (`apps/liminal-hotel-desktop/electron-builder.yml`) prepares artifacts for Windows, macOS, and Linux.
+
+### Firewall & ports
+
+The host button surfaces the port and LAN endpoints inside the lobby. If Windows/macOS prompts for firewall permission, allow incoming connections so friends on the same network can join via the displayed `ws://` URLs. If the selected port is blocked, the host status feed highlights the error and you can retry.
+
+## Microphone privacy & calibration
+
+The client never forwards raw audio. The `MicLevel` helper samples microphone loudness, smooths it, applies hysteresis, and only transmits a scalar value (0–100) plus the push-to-talk flag. Toggle privacy options under **Options → Privacy**:
+
+- **Microphone** — request or release microphone access.
+- **Push-to-Talk (V)** — gate loudness updates behind the `V` key.
+- **Sensitivity** — adjust the dBFS threshold for the voice detector.
+- **Calibrate** — record ambient noise for ~2 seconds and subtract it from future levels.
+
+The HUD displays when the mic is active and how strong the captured loudness is. Silence or disabled microphones mean the Host AI cannot “hear” you.
+
+## Lobby workflow
+
+1. Launch the client (web or desktop).
+2. Choose **Connect** and enter the WebSocket URL, or click **Host local** inside the desktop build.
+3. Once connected, the options menu persists your mic settings for the session, and the HUD shows real-time loudness feedback.
+4. Use the shared LAN URLs (desktop app) to invite other players into the same authoritative server room.
+
+## Scripts quick reference
+
+| Command | Description |
+| --- | --- |
+| `npm run dev:web` | Start Vite dev server for the web client. |
+| `npm run dev:server` | Run the Node server in watch mode via `tsx`. |
+| `npm run dev:desktop` | Build Electron sources and open the desktop shell. |
+| `npm run build --workspace server` | Compile the server to `dist/`. |
+| `npm run build --workspace web/liminal-hotel` | Build the static web client. |
+| `npm run build:desktop` | Package the Electron desktop application (requires built client/server). |
 

--- a/apps/liminal-hotel-desktop/electron-builder.yml
+++ b/apps/liminal-hotel-desktop/electron-builder.yml
@@ -1,0 +1,17 @@
+appId: com.liminal.hotel
+productName: Liminal Hotel
+files:
+  - dist/main/**/*
+  - dist/preload/**/*
+  - ../../web/liminal-hotel/dist/**/*
+extraFiles:
+  - from: ../../server/dist
+    to: resources/server
+mac:
+  category: public.app-category.games
+linux:
+  target:
+    - AppImage
+win:
+  target:
+    - nsis

--- a/apps/liminal-hotel-desktop/package.json
+++ b/apps/liminal-hotel-desktop/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "liminal-hotel-desktop",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/main/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "npm run build:main && npm run build:preload",
+    "build:main": "tsc -p tsconfig.main.json",
+    "build:preload": "tsc -p tsconfig.preload.json",
+    "dev": "npm run build && electron .",
+    "start": "electron .",
+    "package": "npm run build && electron-builder --dir",
+    "dist": "npm run build && electron-builder"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "electron": "^28.2.5",
+    "electron-builder": "^24.6.4",
+    "typescript": "^5.4.2"
+  },
+  "dependencies": {
+    "portfinder": "^1.0.32"
+  }
+}

--- a/apps/liminal-hotel-desktop/src/main/index.ts
+++ b/apps/liminal-hotel-desktop/src/main/index.ts
@@ -1,0 +1,181 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { spawn, ChildProcessWithoutNullStreams } from 'node:child_process';
+import os from 'node:os';
+import process from 'node:process';
+import portfinder from 'portfinder';
+
+let mainWindow: BrowserWindow | null = null;
+let serverProcess: ChildProcessWithoutNullStreams | null = null;
+let currentServerPort: number | null = null;
+
+const WEB_DIST = resolve(__dirname, '../../../web/liminal-hotel/dist/index.html');
+const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL ?? 'http://localhost:5173';
+const SERVER_DIST = resolve(__dirname, '../../../server/dist/index.js');
+
+function createWindow(): void {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 720,
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  if (app.isPackaged || existsSync(WEB_DIST)) {
+    void mainWindow.loadFile(WEB_DIST);
+  } else {
+    void mainWindow.loadURL(DEV_SERVER_URL);
+  }
+}
+
+async function startLocalServer(): Promise<{ wsUrl: string; port: number; lanAddresses: string[] }> {
+  if (serverProcess && currentServerPort) {
+    return {
+      wsUrl: `ws://localhost:${currentServerPort}`,
+      port: currentServerPort,
+      lanAddresses: getLanAddresses(currentServerPort),
+    };
+  }
+
+  const port = await portfinder.getPortPromise({ port: 8787, stopPort: 8899 });
+
+  if (!existsSync(SERVER_DIST)) {
+    throw new Error('No se encontró la build del servidor. Ejecuta npm run build --workspace server.');
+  }
+
+  const child = spawn(process.execPath, [SERVER_DIST], {
+    cwd: resolve(__dirname, '../../../server'),
+    env: {
+      ...process.env,
+      NODE_ENV: process.env.NODE_ENV ?? 'production',
+      PORT: String(port),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  serverProcess = child;
+  currentServerPort = port;
+
+  child.stdout?.on('data', (chunk) => {
+    const message = chunk.toString().trim();
+    mainWindow?.webContents.send('liminalHost:status', message);
+  });
+
+  child.stderr?.on('data', (chunk) => {
+    const message = chunk.toString().trim();
+    mainWindow?.webContents.send('liminalHost:status', `⚠️ ${message}`);
+  });
+
+  try {
+    await waitForServerReady(child);
+  } catch (error) {
+    serverProcess = null;
+    currentServerPort = null;
+    child.kill();
+    throw error;
+  }
+
+  child.once('exit', (code) => {
+    const message = code === 0 ? 'Servidor detenido' : `Servidor salió con código ${code}`;
+    mainWindow?.webContents.send('liminalHost:status', message);
+    serverProcess = null;
+    currentServerPort = null;
+  });
+
+  return {
+    wsUrl: `ws://localhost:${port}`,
+    port,
+    lanAddresses: getLanAddresses(port),
+  };
+}
+
+async function waitForServerReady(child: ChildProcessWithoutNullStreams): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error('El servidor tardó demasiado en iniciar.'));
+    }, 5000);
+
+    const handleData = (chunk: Buffer): void => {
+      const text = chunk.toString();
+      if (text.toLowerCase().includes('listening')) {
+        cleanup();
+        resolve();
+      }
+    };
+
+    const handleExit = (code: number | null): void => {
+      cleanup();
+      reject(new Error(`El servidor terminó antes de iniciar (código ${code ?? 'desconocido'}).`));
+    };
+
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      child.stdout?.off('data', handleData);
+      child.off('exit', handleExit);
+    };
+
+    child.stdout?.on('data', handleData);
+    child.once('exit', handleExit);
+  });
+}
+
+async function stopLocalServer(): Promise<void> {
+  if (!serverProcess) {
+    return;
+  }
+  return new Promise((resolve) => {
+    serverProcess?.once('exit', () => resolve());
+    serverProcess?.kill();
+  });
+}
+
+function getLanAddresses(port: number): string[] {
+  const interfaces = os.networkInterfaces();
+  const addresses: string[] = [];
+  for (const iface of Object.values(interfaces)) {
+    if (!iface) continue;
+    for (const info of iface) {
+      if (info.internal) continue;
+      if (info.family === 'IPv4' && info.address) {
+        addresses.push(`ws://${info.address}:${port}`);
+      }
+    }
+  }
+  return addresses;
+}
+
+app.on('window-all-closed', async () => {
+  if (process.platform !== 'darwin') {
+    await stopLocalServer();
+    app.quit();
+  }
+});
+
+app.on('before-quit', async () => {
+  await stopLocalServer();
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});
+
+app.whenReady().then(() => {
+  createWindow();
+
+  ipcMain.handle('liminalHost:start', async () => {
+    const info = await startLocalServer();
+    return info;
+  });
+
+  ipcMain.handle('liminalHost:stop', async () => {
+    await stopLocalServer();
+    return true;
+  });
+});

--- a/apps/liminal-hotel-desktop/src/preload/index.ts
+++ b/apps/liminal-hotel-desktop/src/preload/index.ts
@@ -1,0 +1,21 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+type ServerReadyPayload = {
+  wsUrl: string;
+  port: number;
+  lanAddresses: string[];
+};
+
+contextBridge.exposeInMainWorld('liminalHost', {
+  async startServer(): Promise<ServerReadyPayload> {
+    return ipcRenderer.invoke('liminalHost:start');
+  },
+  async stopServer(): Promise<void> {
+    await ipcRenderer.invoke('liminalHost:stop');
+  },
+  subscribe(callback: (status: string) => void): () => void {
+    const listener = (_event: Electron.IpcRendererEvent, status: string) => callback(status);
+    ipcRenderer.on('liminalHost:status', listener);
+    return () => ipcRenderer.removeListener('liminalHost:status', listener);
+  },
+});

--- a/apps/liminal-hotel-desktop/tsconfig.main.json
+++ b/apps/liminal-hotel-desktop/tsconfig.main.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.shared.json",
+  "compilerOptions": {
+    "outDir": "dist/main"
+  },
+  "include": ["src/main/**/*.ts"]
+}

--- a/apps/liminal-hotel-desktop/tsconfig.preload.json
+++ b/apps/liminal-hotel-desktop/tsconfig.preload.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.shared.json",
+  "compilerOptions": {
+    "outDir": "dist/preload"
+  },
+  "include": ["src/preload/**/*.ts"]
+}

--- a/apps/liminal-hotel-desktop/tsconfig.shared.json
+++ b/apps/liminal-hotel-desktop/tsconfig.shared.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "types": ["node"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "liminal-hotel-monorepo",
+  "private": true,
+  "workspaces": [
+    "server",
+    "web/liminal-hotel",
+    "apps/liminal-hotel-desktop"
+  ],
+  "scripts": {
+    "dev:web": "npm --workspace web/liminal-hotel run dev",
+    "dev:server": "npm --workspace server run dev",
+    "dev:desktop": "npm --workspace apps/liminal-hotel-desktop run dev",
+    "build:desktop": "npm --workspace apps/liminal-hotel-desktop run dist"
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "liminal-hotel-server",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "ws": "^8.15.1"
+  },
+  "devDependencies": {
+    "tsx": "^3.12.7",
+    "typescript": "^5.4.2"
+  }
+}

--- a/server/src/game/GameRoom.ts
+++ b/server/src/game/GameRoom.ts
@@ -1,0 +1,56 @@
+import { isMicMessage } from '../net/messages';
+import { HostAI } from './HostAI';
+import { Player } from './Player';
+
+export class GameRoom {
+  private players = new Map<string, Player>();
+  private host = new HostAI();
+  private lastTick = Date.now();
+
+  public addPlayer(id: string): Player {
+    const player = new Player(id);
+    this.players.set(id, player);
+    return player;
+  }
+
+  public removePlayer(id: string): void {
+    this.players.delete(id);
+  }
+
+  public processMessage(playerId: string, raw: unknown): void {
+    if (!isMicMessage(raw)) {
+      return;
+    }
+    if (!this.players.has(playerId)) {
+      this.addPlayer(playerId);
+    }
+
+    const { level } = raw;
+    if (!Number.isFinite(level)) {
+      return;
+    }
+
+    const player = this.players.get(playerId)!;
+    player.applyMicLevel(level, Date.now());
+  }
+
+  public tick(): void {
+    const now = Date.now();
+    const delta = (now - this.lastTick) / 1000;
+    this.lastTick = now;
+
+    for (const player of this.players.values()) {
+      player.updateDecay(delta);
+    }
+
+    this.host.update(Array.from(this.players.values()));
+  }
+
+  public getHost(): HostAI {
+    return this.host;
+  }
+
+  public getPlayers(): Player[] {
+    return Array.from(this.players.values());
+  }
+}

--- a/server/src/game/HostAI.ts
+++ b/server/src/game/HostAI.ts
@@ -1,0 +1,49 @@
+import { Player, Vec3 } from './Player';
+
+export type HostState = 'patrol' | 'search' | 'investigate' | 'chase';
+
+function distance(a: Vec3, b: Vec3): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+export class HostAI {
+  public state: HostState = 'patrol';
+  public heardAt: Vec3 | null = null;
+  public chaseAggression = 0;
+
+  constructor(public position: Vec3 = { x: 0, y: 0, z: 0 }) {}
+
+  public update(players: Player[]): void {
+    let loudest: { player: Player; radius: number } | null = null;
+    for (const player of players) {
+      if (player.noiseRadius <= 0) {
+        continue;
+      }
+      const dist = distance(player.position, this.position);
+      if (dist <= player.noiseRadius) {
+        if (!loudest || player.noiseRadius > loudest.radius) {
+          loudest = { player, radius: player.noiseRadius };
+        }
+      }
+    }
+
+    if (loudest) {
+      this.heardAt = { ...loudest.player.position };
+      this.chaseAggression = Math.min(1, loudest.radius / 18);
+      if (this.state === 'patrol' || this.state === 'search') {
+        this.state = 'investigate';
+      } else if (this.state === 'investigate') {
+        this.state = 'chase';
+      }
+    } else if (this.state === 'chase') {
+      this.state = 'investigate';
+      this.chaseAggression = 0;
+    } else if (this.state === 'investigate') {
+      this.state = 'search';
+      this.chaseAggression = 0;
+    }
+  }
+}

--- a/server/src/game/Player.ts
+++ b/server/src/game/Player.ts
@@ -1,0 +1,33 @@
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export class Player {
+  public noiseRadius = 0;
+  private lastMicTimestamp = 0;
+
+  constructor(public readonly id: string, public position: Vec3 = { x: 0, y: 0, z: 0 }) {}
+
+  public applyMicLevel(level: number, timestamp: number, maxRadius = 18): void {
+    if (timestamp - this.lastMicTimestamp < 50) {
+      return;
+    }
+    this.lastMicTimestamp = timestamp;
+    const clamped = Math.max(0, Math.min(100, Number.isFinite(level) ? level : 0));
+    const radius = (clamped / 100) * maxRadius;
+    this.noiseRadius = radius;
+  }
+
+  public updateDecay(deltaSeconds: number): void {
+    if (this.noiseRadius <= 0) {
+      return;
+    }
+    const decayFactor = Math.pow(0.8, deltaSeconds); // ~20% per second
+    this.noiseRadius *= decayFactor;
+    if (this.noiseRadius < 0.01) {
+      this.noiseRadius = 0;
+    }
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,84 @@
+import { createServer } from 'http';
+import { AddressInfo } from 'net';
+import process from 'node:process';
+import { WebSocketServer } from 'ws';
+import { GameRoom } from './game/GameRoom';
+import { isMicMessage } from './net/messages';
+
+function parsePort(): number {
+  const argPort = process.argv.find((arg) => arg.startsWith('--port='));
+  if (argPort) {
+    const value = Number(argPort.split('=')[1]);
+    if (Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  }
+  const envPort = Number(process.env.PORT ?? '');
+  if (Number.isFinite(envPort) && envPort > 0) {
+    return envPort;
+  }
+  return 3000;
+}
+
+export function startServer(): { close(): Promise<void>; port: number } {
+  const httpServer = createServer();
+  const wss = new WebSocketServer({ server: httpServer });
+  const room = new GameRoom();
+
+  wss.on('connection', (socket) => {
+    const playerId = `player-${Math.random().toString(36).slice(2)}`;
+    room.addPlayer(playerId);
+
+    socket.on('message', (data) => {
+      try {
+        const payload = JSON.parse(String(data));
+        if (isMicMessage(payload)) {
+          room.processMessage(playerId, payload);
+        }
+      } catch (error) {
+        console.warn('Invalid message', error);
+      }
+    });
+
+    socket.on('close', () => {
+      room.removePlayer(playerId);
+    });
+  });
+
+  const tickInterval = setInterval(() => room.tick(), 1000 / 10);
+
+  const port = parsePort();
+
+  httpServer.listen(port, () => {
+    const address = httpServer.address() as AddressInfo | null;
+    console.log(
+      address
+        ? `Server listening on ws://localhost:${address.port}`
+        : `Server listening on port ${port}`,
+    );
+  });
+
+  const close = async (): Promise<void> => {
+    clearInterval(tickInterval);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  };
+
+  return { close, port };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { port } = startServer();
+  process.on('SIGINT', () => {
+    console.log('Shutting down server...');
+    process.exit(0);
+  });
+  console.log(`Liminal Hotel server started on port ${port}`);
+}

--- a/server/src/net/messages.ts
+++ b/server/src/net/messages.ts
@@ -1,0 +1,22 @@
+export interface MicMessage {
+  type: 'mic';
+  level: number;
+  flags?: {
+    pushToTalk?: boolean;
+    enabled?: boolean;
+  };
+}
+
+export type ClientMessage = MicMessage;
+
+export function isMicMessage(payload: unknown): payload is MicMessage {
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+  const candidate = payload as Partial<MicMessage>;
+  if (candidate.type !== 'mic') {
+    return false;
+  }
+  const level = (candidate as { level?: unknown }).level;
+  return typeof level === 'number' && Number.isFinite(level);
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/web/liminal-hotel/index.html
+++ b/web/liminal-hotel/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Liminal Hotel</title>
+  </head>
+  <body>
+    <div id="app">
+      <main id="lobby"></main>
+      <section id="hud"></section>
+      <section id="options"></section>
+    </div>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/web/liminal-hotel/package.json
+++ b/web/liminal-hotel/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "liminal-hotel-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.2",
+    "vite": "^5.2.0"
+  }
+}

--- a/web/liminal-hotel/src/audio/MicLevel.ts
+++ b/web/liminal-hotel/src/audio/MicLevel.ts
@@ -1,0 +1,276 @@
+/*
+ * Microphone level capture with privacy-preserving voice activity detection.
+ */
+
+export interface MicLevelCallbacks {
+  onLevel?: (level: number) => void;
+  onVadChange?: (active: boolean) => void;
+  onPermissionChange?: (granted: boolean) => void;
+}
+
+export interface MicLevelOptions {
+  sensitivityDb?: number; // Threshold in dBFS for voice detection.
+  smoothing?: number; // Exponential smoothing factor for the RMS level.
+  vadHoldMs?: number; // Time that voice must stay above threshold before reporting.
+  vadReleaseMs?: number; // Time before we consider voice ended.
+  fftSize?: number;
+  frameRate?: number; // Updates per second.
+  pushToTalk?: boolean;
+  ambientLevel?: number; // Calibration offset for ambient noise (0-100).
+}
+
+const DEFAULT_OPTIONS: Required<Pick<MicLevelOptions,
+  'sensitivityDb' | 'smoothing' | 'vadHoldMs' | 'vadReleaseMs' | 'fftSize' | 'frameRate' | 'pushToTalk' | 'ambientLevel'
+>> = {
+  sensitivityDb: -50,
+  smoothing: 0.2,
+  vadHoldMs: 200,
+  vadReleaseMs: 350,
+  fftSize: 512,
+  frameRate: 12,
+  pushToTalk: false,
+  ambientLevel: 0,
+};
+
+const LEVEL_MIN_DB = -100;
+const LEVEL_MAX_DB = 0;
+
+export class MicLevel {
+  private stream: MediaStream | null = null;
+  private context: AudioContext | null = null;
+  private source: MediaStreamAudioSourceNode | null = null;
+  private analyser: AnalyserNode | null = null;
+  private dataArray: Float32Array = new Float32Array(0);
+  private rafId: number | null = null;
+  private intervalId: number | null = null;
+  private running = false;
+  private levelEma = 0;
+  private vadActive = false;
+  private aboveThresholdFrames = 0;
+  private belowThresholdFrames = 0;
+  private pushToTalkHeld = false;
+  private lastLevelSent = 0;
+
+  private options: Required<typeof DEFAULT_OPTIONS>;
+
+  constructor(private callbacks: MicLevelCallbacks = {}, options: MicLevelOptions = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleKeyUp = this.handleKeyUp.bind(this);
+    window.addEventListener('keydown', this.handleKeyDown);
+    window.addEventListener('keyup', this.handleKeyUp);
+  }
+
+  public get isRunning(): boolean {
+    return this.running;
+  }
+
+  public get pushToTalk(): boolean {
+    return this.options.pushToTalk;
+  }
+
+  public set pushToTalk(enabled: boolean) {
+    this.options.pushToTalk = enabled;
+  }
+
+  public get sensitivityDb(): number {
+    return this.options.sensitivityDb;
+  }
+
+  public set sensitivityDb(value: number) {
+    this.options.sensitivityDb = value;
+  }
+
+  public set ambientLevel(value: number) {
+    this.options.ambientLevel = Math.max(0, Math.min(100, value));
+  }
+
+  public get ambientLevel(): number {
+    return this.options.ambientLevel;
+  }
+
+  public async start(): Promise<void> {
+    if (this.running) {
+      return;
+    }
+
+    try {
+      this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      this.callbacks.onPermissionChange?.(true);
+    } catch (error) {
+      console.warn('[MicLevel] Failed to obtain microphone access', error);
+      this.callbacks.onPermissionChange?.(false);
+      throw error;
+    }
+
+    this.context = new AudioContext();
+    this.source = this.context.createMediaStreamSource(this.stream);
+    this.analyser = this.context.createAnalyser();
+    this.analyser.fftSize = this.options.fftSize;
+    this.analyser.smoothingTimeConstant = 0.0;
+
+    this.source.connect(this.analyser);
+
+    const bufferLength = this.analyser.fftSize;
+    this.dataArray = new Float32Array(bufferLength);
+    this.running = true;
+    this.levelEma = 0;
+    this.aboveThresholdFrames = 0;
+    this.belowThresholdFrames = 0;
+
+    const updateInterval = 1000 / this.options.frameRate;
+    this.intervalId = window.setInterval(() => this.sample(), updateInterval);
+  }
+
+  public stop(): void {
+    if (!this.running) {
+      return;
+    }
+
+    if (this.intervalId !== null) {
+      window.clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+
+    if (this.rafId !== null) {
+      window.cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+
+    this.running = false;
+    this.levelEma = 0;
+    this.setVad(false);
+
+    this.analyser?.disconnect();
+    this.source?.disconnect();
+
+    this.stream?.getTracks().forEach(track => track.stop());
+    this.stream = null;
+
+    this.context?.close();
+    this.context = null;
+  }
+
+  public destroy(): void {
+    this.stop();
+    window.removeEventListener('keydown', this.handleKeyDown);
+    window.removeEventListener('keyup', this.handleKeyUp);
+  }
+
+  public async calibrate(durationMs = 2000): Promise<void> {
+    if (!this.running) {
+      await this.start();
+    }
+
+    const samples: number[] = [];
+    const start = performance.now();
+
+    return new Promise((resolve) => {
+      const collect = () => {
+        const now = performance.now();
+        if (now - start >= durationMs) {
+          const avg = samples.length ? samples.reduce((a, b) => a + b, 0) / samples.length : 0;
+          this.options.ambientLevel = Math.min(100, Math.max(0, avg));
+          if (this.rafId !== null) {
+            window.cancelAnimationFrame(this.rafId);
+            this.rafId = null;
+          }
+          resolve();
+          return;
+        }
+        const db = this.sampleInstantDb();
+        samples.push(this.mapDbToScalar(db));
+        this.rafId = window.requestAnimationFrame(collect);
+      };
+      collect();
+    });
+  }
+
+  private sample(): void {
+    const db = this.sampleInstantDb();
+    const clampedDb = Math.max(LEVEL_MIN_DB, Math.min(LEVEL_MAX_DB, db));
+
+    const normalized = this.mapDbToScalar(clampedDb);
+    const compensated = Math.max(0, normalized - this.options.ambientLevel);
+    this.levelEma = this.options.smoothing * compensated + (1 - this.options.smoothing) * this.levelEma;
+    const levelToSend = Math.round(this.levelEma);
+
+    this.updateVad(clampedDb);
+
+    const shouldEmit = !this.options.pushToTalk || this.pushToTalkHeld;
+    if (shouldEmit) {
+      this.callbacks.onLevel?.(levelToSend);
+      this.lastLevelSent = levelToSend;
+    } else if (this.lastLevelSent !== 0) {
+      this.lastLevelSent = 0;
+      this.callbacks.onLevel?.(0);
+    }
+  }
+
+  private sampleInstantDb(): number {
+    if (!this.analyser) {
+      return LEVEL_MIN_DB;
+    }
+    this.analyser.getFloatTimeDomainData(this.dataArray);
+
+    let sumSquares = 0;
+    for (let i = 0; i < this.dataArray.length; i += 1) {
+      const value = this.dataArray[i];
+      sumSquares += value * value;
+    }
+    const rms = Math.sqrt(sumSquares / this.dataArray.length) || 0;
+    const db = 20 * Math.log10(rms || 1e-8);
+    return Math.max(LEVEL_MIN_DB, Math.min(LEVEL_MAX_DB, db));
+  }
+
+  private updateVad(db: number): void {
+    const isAbove = db >= this.options.sensitivityDb;
+    if (isAbove) {
+      this.aboveThresholdFrames += 1;
+      this.belowThresholdFrames = 0;
+      const holdFrames = Math.max(1, Math.round((this.options.vadHoldMs / 1000) * this.options.frameRate));
+      if (!this.vadActive && this.aboveThresholdFrames >= holdFrames) {
+        this.setVad(true);
+      }
+    } else {
+      this.belowThresholdFrames += 1;
+      this.aboveThresholdFrames = 0;
+      const releaseFrames = Math.max(1, Math.round((this.options.vadReleaseMs / 1000) * this.options.frameRate));
+      if (this.vadActive && this.belowThresholdFrames >= releaseFrames) {
+        this.setVad(false);
+      }
+    }
+  }
+
+  private setVad(active: boolean): void {
+    if (this.vadActive === active) {
+      return;
+    }
+    this.vadActive = active;
+    this.callbacks.onVadChange?.(active);
+  }
+
+  private mapDbToScalar(db: number): number {
+    const normalized = (db - LEVEL_MIN_DB) / (LEVEL_MAX_DB - LEVEL_MIN_DB);
+    const curved = Math.pow(Math.max(0, Math.min(1, normalized)), 0.5);
+    return Math.round(curved * 100);
+  }
+
+  private handleKeyDown(event: KeyboardEvent): void {
+    if (!this.options.pushToTalk) {
+      return;
+    }
+    if (event.key.toLowerCase() === 'v') {
+      this.pushToTalkHeld = true;
+    }
+  }
+
+  private handleKeyUp(event: KeyboardEvent): void {
+    if (!this.options.pushToTalk) {
+      return;
+    }
+    if (event.key.toLowerCase() === 'v') {
+      this.pushToTalkHeld = false;
+    }
+  }
+}

--- a/web/liminal-hotel/src/main.ts
+++ b/web/liminal-hotel/src/main.ts
@@ -1,0 +1,6 @@
+import './style.css';
+import { bootstrap } from './state/GameClient';
+
+document.addEventListener('DOMContentLoaded', () => {
+  bootstrap();
+});

--- a/web/liminal-hotel/src/net/NetClient.ts
+++ b/web/liminal-hotel/src/net/NetClient.ts
@@ -1,0 +1,176 @@
+import { MicLevel } from '../audio/MicLevel';
+
+export interface MicConfigState {
+  enabled: boolean;
+  sensitivityDb: number;
+  pushToTalk: boolean;
+  ambientLevel: number;
+}
+
+export interface MicHudCallbacks {
+  onLevelChange(level: number): void;
+  onVad(active: boolean): void;
+  onMicActive(active: boolean): void;
+  onPushToTalkChange?(enabled: boolean): void;
+}
+
+export interface NetworkTransport {
+  send(data: unknown): void;
+  isConnected(): boolean;
+}
+
+interface MicMessage {
+  type: 'mic';
+  level: number;
+  flags: {
+    pushToTalk: boolean;
+    enabled: boolean;
+  };
+}
+
+const MIC_UPDATE_INTERVAL_MS = 1000 / 12;
+
+export class NetClient {
+  private mic: MicLevel | null = null;
+  private micTimer: number | null = null;
+  private lastMicPayload = 0;
+  private micConfig: MicConfigState = {
+    enabled: false,
+    sensitivityDb: -50,
+    pushToTalk: false,
+    ambientLevel: 0,
+  };
+
+  constructor(private transport: NetworkTransport, private hud: MicHudCallbacks) {}
+
+  public get micEnabled(): boolean {
+    return this.micConfig.enabled;
+  }
+
+  public async enableMic(): Promise<void> {
+    if (this.micConfig.enabled) {
+      return;
+    }
+    const mic = this.ensureMic();
+    await mic.start();
+    this.micConfig.enabled = true;
+    this.hud.onMicActive(true);
+    this.startMicLoop();
+  }
+
+  public disableMic(): void {
+    this.micConfig.enabled = false;
+    if (this.micTimer) {
+      window.clearInterval(this.micTimer);
+      this.micTimer = null;
+    }
+    this.mic?.stop();
+    this.hud.onMicActive(false);
+    this.sendMicLevel(0);
+  }
+
+  public setSensitivity(db: number): void {
+    this.micConfig.sensitivityDb = db;
+    if (this.mic) {
+      this.mic.sensitivityDb = db;
+    }
+  }
+
+  public setPushToTalk(enabled: boolean): void {
+    this.micConfig.pushToTalk = enabled;
+    if (this.mic) {
+      this.mic.pushToTalk = enabled;
+    }
+    this.hud.onPushToTalkChange?.(enabled);
+  }
+
+  public setAmbientLevel(level: number): void {
+    this.micConfig.ambientLevel = Math.max(0, Math.min(100, level));
+    if (this.mic) {
+      this.mic.ambientLevel = this.micConfig.ambientLevel;
+    }
+  }
+
+  public getAmbientLevel(): number {
+    return this.micConfig.ambientLevel;
+  }
+
+  public async calibrateMic(): Promise<void> {
+    const mic = this.ensureMic();
+    const wasEnabled = this.micConfig.enabled;
+    const wasRunning = mic.isRunning;
+    if (!wasRunning) {
+      await mic.start();
+      if (!wasEnabled) {
+        this.hud.onMicActive(true);
+      }
+    }
+    await mic.calibrate();
+    this.setAmbientLevel(mic.ambientLevel);
+    if (!wasEnabled) {
+      mic.stop();
+      this.hud.onMicActive(false);
+    }
+  }
+
+  private startMicLoop(): void {
+    if (this.micTimer) {
+      window.clearInterval(this.micTimer);
+    }
+    this.micTimer = window.setInterval(() => {
+      if (!this.transport.isConnected()) {
+        return;
+      }
+      if (!this.micEnabled) {
+        this.sendMicLevel(0);
+      }
+    }, MIC_UPDATE_INTERVAL_MS);
+  }
+
+  private handleMicLevel(level: number): void {
+    this.hud.onLevelChange(level);
+    if (this.micConfig.enabled) {
+      this.sendMicLevel(level);
+    }
+  }
+
+  private sendMicLevel(level: number): void {
+    const clamped = Math.min(100, Math.max(0, Number.isFinite(level) ? level : 0));
+    if (clamped === this.lastMicPayload) {
+      return;
+    }
+    this.lastMicPayload = clamped;
+    const message: MicMessage = {
+      type: 'mic',
+      level: clamped,
+      flags: {
+        pushToTalk: this.micConfig.pushToTalk,
+        enabled: this.micConfig.enabled,
+      },
+    };
+    this.transport.send(message);
+  }
+
+  private ensureMic(): MicLevel {
+    if (!this.mic) {
+      this.mic = new MicLevel(
+        {
+          onLevel: (level) => this.handleMicLevel(level),
+          onVadChange: (active) => this.hud.onVad(active),
+          onPermissionChange: (granted) => {
+            this.hud.onMicActive(granted);
+            if (!granted) {
+              this.disableMic();
+            }
+          },
+        },
+        {
+          sensitivityDb: this.micConfig.sensitivityDb,
+          pushToTalk: this.micConfig.pushToTalk,
+          ambientLevel: this.micConfig.ambientLevel,
+        },
+      );
+    }
+    return this.mic;
+  }
+}

--- a/web/liminal-hotel/src/net/WebSocketTransport.ts
+++ b/web/liminal-hotel/src/net/WebSocketTransport.ts
@@ -1,0 +1,93 @@
+import { NetworkTransport } from './NetClient';
+
+export interface TransportEvents {
+  onClose?: () => void;
+  onError?: (error: Event | Error) => void;
+}
+
+export class WebSocketTransport implements NetworkTransport {
+  private socket: WebSocket | null = null;
+  private currentUrl: string | null = null;
+  private manualClose = false;
+
+  constructor(private readonly events: TransportEvents = {}) {}
+
+  public async connect(url: string): Promise<void> {
+    await this.disconnect();
+    this.manualClose = false;
+
+    await new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(url);
+      this.socket = ws;
+      this.currentUrl = url;
+      let opened = false;
+
+      const handleOpen = (): void => {
+        opened = true;
+        ws.removeEventListener('open', handleOpen);
+        resolve();
+      };
+
+      const handleError = (event: Event): void => {
+        ws.removeEventListener('open', handleOpen);
+        this.events.onError?.(event);
+        if (!opened) {
+          cleanup();
+          reject(new Error('Failed to connect.'));
+        }
+      };
+
+      const handleClose = (): void => {
+        if (this.socket === ws) {
+          this.socket = null;
+          this.currentUrl = null;
+        }
+        if (!this.manualClose) {
+          if (!opened) {
+            reject(new Error('Connection closed before ready.'));
+          }
+          this.events.onClose?.();
+        }
+      };
+
+      const cleanup = (): void => {
+        ws.removeEventListener('error', handleError);
+        ws.removeEventListener('close', handleClose);
+      };
+
+      ws.addEventListener('open', handleOpen);
+      ws.addEventListener('error', handleError);
+      ws.addEventListener('close', handleClose, { once: false });
+    });
+  }
+
+  public async disconnect(): Promise<void> {
+    if (!this.socket) {
+      return;
+    }
+    const ws = this.socket;
+    this.manualClose = true;
+    this.socket = null;
+    this.currentUrl = null;
+
+    await new Promise<void>((resolve) => {
+      ws.addEventListener('close', () => resolve(), { once: true });
+      ws.close();
+    });
+  }
+
+  public send(data: unknown): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    this.socket.send(JSON.stringify(data));
+  }
+
+  public isConnected(): boolean {
+    return this.socket?.readyState === WebSocket.OPEN ?? false;
+  }
+
+  public get url(): string | null {
+    return this.currentUrl;
+  }
+}

--- a/web/liminal-hotel/src/platform/hostBridge.ts
+++ b/web/liminal-hotel/src/platform/hostBridge.ts
@@ -1,0 +1,58 @@
+export interface ServerReadyPayload {
+  wsUrl: string;
+  port: number;
+  lanAddresses: string[];
+}
+
+export interface HostBridge {
+  readonly isElectron: boolean;
+  startLocalServer(): Promise<ServerReadyPayload>;
+  stopLocalServer(): Promise<void>;
+  onStatus(callback: (status: string) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    liminalHost?: {
+      startServer(): Promise<ServerReadyPayload>;
+      stopServer(): Promise<void>;
+      subscribe(callback: (status: string) => void): () => void;
+    };
+  }
+}
+
+class BrowserHostBridge implements HostBridge {
+  public readonly isElectron = false;
+
+  public async startLocalServer(): Promise<ServerReadyPayload> {
+    throw new Error('Local hosting is only available in the desktop app.');
+  }
+
+  public async stopLocalServer(): Promise<void> {
+    // No-op.
+  }
+
+  public onStatus(): () => void {
+    return () => {};
+  }
+}
+
+class ElectronHostBridge implements HostBridge {
+  public readonly isElectron = true;
+
+  public startLocalServer(): Promise<ServerReadyPayload> {
+    return window.liminalHost!.startServer();
+  }
+
+  public stopLocalServer(): Promise<void> {
+    return window.liminalHost!.stopServer();
+  }
+
+  public onStatus(callback: (status: string) => void): () => void {
+    return window.liminalHost!.subscribe(callback);
+  }
+}
+
+export const hostBridge: HostBridge = window.liminalHost
+  ? new ElectronHostBridge()
+  : new BrowserHostBridge();

--- a/web/liminal-hotel/src/state/GameClient.ts
+++ b/web/liminal-hotel/src/state/GameClient.ts
@@ -1,0 +1,64 @@
+import { NetClient } from '../net/NetClient';
+import { WebSocketTransport } from '../net/WebSocketTransport';
+import { HudMicIndicator } from '../ui/HudMicIndicator';
+import { Lobby } from '../ui/Lobby';
+import { OptionsMenu } from '../ui/OptionsMenu';
+
+export class GameClient {
+  private readonly hud: HudMicIndicator;
+  private readonly transport: WebSocketTransport;
+  private readonly net: NetClient;
+  private readonly options: OptionsMenu;
+  private readonly lobby: Lobby;
+
+  constructor(hudContainer: HTMLElement, menuContainer: HTMLElement, lobbyContainer: HTMLElement) {
+    this.hud = new HudMicIndicator();
+    this.hud.mount(hudContainer);
+
+    this.lobby = new Lobby({
+      onConnect: (url) => void this.connect(url),
+      onDisconnect: () => void this.disconnect(),
+    });
+    this.lobby.mount(lobbyContainer);
+
+    this.transport = new WebSocketTransport({
+      onClose: () => this.lobby.updateDisconnected(),
+      onError: () => this.lobby.showError('Error de conexión'),
+    });
+    this.net = new NetClient(this.transport, this.hud);
+
+    this.options = new OptionsMenu(this.net);
+    this.options.mount(menuContainer);
+  }
+
+  private async connect(url: string): Promise<void> {
+    try {
+      await this.transport.connect(url);
+      this.lobby.updateConnected(url);
+    } catch (error) {
+      await this.transport.disconnect();
+      this.lobby.updateDisconnected();
+      this.lobby.showError(error instanceof Error ? error.message : 'No se pudo conectar.');
+    }
+  }
+
+  private async disconnect(): Promise<void> {
+    await this.transport.disconnect();
+    this.lobby.updateDisconnected();
+  }
+}
+
+export function bootstrap(): void {
+  const hudContainer = document.getElementById('hud') ?? document.body;
+  const menuContainer = document.getElementById('options') ?? document.body;
+  const lobbyContainer = document.getElementById('lobby') ?? document.body;
+  new GameClient(hudContainer, menuContainer, lobbyContainer);
+}
+
+declare global {
+  interface Window {
+    bootstrapGame?: () => void;
+  }
+}
+
+window.bootstrapGame = bootstrap;

--- a/web/liminal-hotel/src/style.css
+++ b/web/liminal-hotel/src/style.css
@@ -1,0 +1,192 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #060608;
+  color: #f1f1f1;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+#app {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-areas:
+    'lobby hud'
+    'options options';
+  gap: 1rem;
+  padding: 1rem;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+main#lobby {
+  grid-area: lobby;
+  background: rgba(15, 17, 24, 0.85);
+  padding: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+section#hud {
+  grid-area: hud;
+}
+
+section#options {
+  grid-area: options;
+}
+
+button, input, select {
+  font: inherit;
+}
+
+.options-menu {
+  background: rgba(15, 17, 24, 0.85);
+  padding: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.options-menu h2 {
+  margin-top: 0;
+}
+
+.options-menu label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.options-menu input[type='range'] {
+  width: 60%;
+}
+
+.mic-warning {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.mic-warning.active {
+  color: #62f5ff;
+  opacity: 1;
+}
+
+.hud-mic-indicator {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: rgba(15, 17, 24, 0.85);
+  padding: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  min-width: 260px;
+}
+
+.hud-mic-bar {
+  width: 100%;
+  height: 12px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.hud-mic-bar-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #45f9b5, #ff7f50);
+  transition: width 0.1s ease;
+}
+
+.hud-mic-indicator.enabled .hud-mic-bar-fill {
+  opacity: 1;
+}
+
+.hud-mic-indicator:not(.enabled) .hud-mic-bar-fill {
+  opacity: 0.2;
+}
+
+.hud-mic-status {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lobby-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.lobby-panel fieldset {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lobby-panel input[type='text'] {
+  width: 280px;
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: none;
+}
+
+.lobby-panel button {
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: none;
+  background: rgba(69, 249, 181, 0.2);
+  color: #45f9b5;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.lobby-panel button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.lobby-panel button:hover:not(:disabled) {
+  background: rgba(69, 249, 181, 0.35);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.status-pill.ready {
+  background: rgba(69, 249, 181, 0.15);
+  color: #45f9b5;
+}
+
+.status-pill.error {
+  background: rgba(255, 99, 132, 0.15);
+  color: #ff718f;
+}
+
+.host-details {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+@media (max-width: 960px) {
+  #app {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'lobby'
+      'hud'
+      'options';
+  }
+}

--- a/web/liminal-hotel/src/ui/HudMicIndicator.ts
+++ b/web/liminal-hotel/src/ui/HudMicIndicator.ts
@@ -1,0 +1,56 @@
+import { MicHudCallbacks } from '../net/NetClient';
+
+export class HudMicIndicator implements MicHudCallbacks {
+  private root: HTMLElement;
+  private barFill: HTMLElement;
+  private status: HTMLElement;
+  private active = false;
+  private pttEnabled = false;
+
+  constructor() {
+    this.root = document.createElement('div');
+    this.root.className = 'hud-mic-indicator';
+
+    const bar = document.createElement('div');
+    bar.className = 'hud-mic-bar';
+
+    this.barFill = document.createElement('div');
+    this.barFill.className = 'hud-mic-bar-fill';
+    bar.appendChild(this.barFill);
+
+    this.status = document.createElement('span');
+    this.status.className = 'hud-mic-status';
+    this.status.textContent = 'MIC OFF';
+
+    this.root.appendChild(bar);
+    this.root.appendChild(this.status);
+  }
+
+  public mount(container: HTMLElement): void {
+    container.appendChild(this.root);
+  }
+
+  public onLevelChange(level: number): void {
+    this.barFill.style.width = `${level}%`;
+  }
+
+  public onVad(active: boolean): void {
+    this.active = active;
+    this.status.textContent = active ? 'VOICE' : this.pttEnabled ? 'MIC PTT' : 'MIC ON';
+    this.root.classList.toggle('speaking', active);
+  }
+
+  public onMicActive(active: boolean): void {
+    this.status.textContent = active ? (this.pttEnabled ? 'MIC PTT' : 'MIC ON') : 'MIC OFF';
+    this.root.classList.toggle('enabled', active);
+    if (!active) {
+      this.onLevelChange(0);
+    }
+  }
+
+  public onPushToTalkChange(enabled: boolean): void {
+    this.pttEnabled = enabled;
+    this.status.textContent = this.pttEnabled ? 'MIC PTT' : this.active ? 'VOICE' : 'MIC ON';
+    this.root.classList.toggle('ptt', enabled);
+  }
+}

--- a/web/liminal-hotel/src/ui/Lobby.ts
+++ b/web/liminal-hotel/src/ui/Lobby.ts
@@ -1,0 +1,162 @@
+import { HostBridge, ServerReadyPayload, hostBridge } from '../platform/hostBridge';
+
+export interface LobbyCallbacks {
+  onConnect(url: string): void;
+  onDisconnect(): void;
+}
+
+type LobbyState =
+  | { kind: 'idle' }
+  | { kind: 'connecting'; target: string }
+  | { kind: 'connected'; target: string }
+  | { kind: 'error'; message: string };
+
+export class Lobby {
+  private readonly root: HTMLElement;
+  private readonly status: HTMLElement;
+  private readonly joinInput: HTMLInputElement;
+  private readonly connectButton: HTMLButtonElement;
+  private readonly hostButton: HTMLButtonElement;
+  private readonly stopButton: HTMLButtonElement;
+  private readonly hostDetails: HTMLElement;
+  private state: LobbyState = { kind: 'idle' };
+  private unsubscribeStatus: (() => void) | null = null;
+
+  constructor(private readonly callbacks: LobbyCallbacks, private readonly bridge: HostBridge = hostBridge) {
+    this.root = document.createElement('div');
+    this.root.className = 'lobby-panel';
+
+    const connectionFieldset = document.createElement('fieldset');
+    const legend = document.createElement('legend');
+    legend.textContent = 'Multiplayer Lobby';
+    connectionFieldset.appendChild(legend);
+
+    this.status = document.createElement('div');
+    this.status.className = 'status-pill';
+    this.status.textContent = 'Disconnected';
+
+    this.joinInput = document.createElement('input');
+    this.joinInput.type = 'text';
+    this.joinInput.placeholder = 'ws://localhost:8787';
+
+    this.connectButton = document.createElement('button');
+    this.connectButton.textContent = 'Connect';
+
+    this.hostButton = document.createElement('button');
+    this.hostButton.textContent = this.bridge.isElectron ? 'Host local (desktop)' : 'Host local';
+
+    this.stopButton = document.createElement('button');
+    this.stopButton.textContent = 'Stop host';
+    this.stopButton.disabled = true;
+
+    this.hostDetails = document.createElement('p');
+    this.hostDetails.className = 'host-details';
+
+    const joinRow = document.createElement('div');
+    joinRow.appendChild(this.joinInput);
+    joinRow.appendChild(this.connectButton);
+
+    const hostRow = document.createElement('div');
+    hostRow.appendChild(this.hostButton);
+    hostRow.appendChild(this.stopButton);
+
+    connectionFieldset.appendChild(this.status);
+    connectionFieldset.appendChild(joinRow);
+    connectionFieldset.appendChild(hostRow);
+    connectionFieldset.appendChild(this.hostDetails);
+
+    const instructions = document.createElement('p');
+    instructions.innerHTML = this.bridge.isElectron
+      ? 'La app de escritorio puede arrancar el servidor en un puerto libre y compartir la IP en LAN.'
+      : 'Para anfitrionar desde navegador, ejecuta <code>npm run server</code> y deja el campo apuntar a ws://localhost:3000.';
+
+    this.root.appendChild(connectionFieldset);
+    this.root.appendChild(instructions);
+
+    this.connectButton.addEventListener('click', () => this.handleConnect());
+    this.hostButton.addEventListener('click', () => this.handleHost());
+    this.stopButton.addEventListener('click', () => this.handleStopHost());
+
+    if (this.bridge.isElectron) {
+      this.unsubscribeStatus = this.bridge.onStatus((status) => {
+        this.hostDetails.textContent = status;
+      });
+    }
+  }
+
+  public mount(container: HTMLElement): void {
+    container.appendChild(this.root);
+  }
+
+  public updateConnected(url: string): void {
+    this.state = { kind: 'connected', target: url };
+    this.status.textContent = `Connected to ${url}`;
+    this.status.classList.remove('error');
+    this.status.classList.add('ready');
+    this.connectButton.disabled = true;
+    this.joinInput.disabled = true;
+    this.hostButton.disabled = true;
+    this.stopButton.disabled = false;
+  }
+
+  public updateDisconnected(): void {
+    this.state = { kind: 'idle' };
+    this.status.textContent = 'Disconnected';
+    this.status.classList.remove('ready', 'error');
+    this.connectButton.disabled = false;
+    this.joinInput.disabled = false;
+    this.hostButton.disabled = false;
+    this.stopButton.disabled = true;
+    this.hostDetails.textContent = '';
+  }
+
+  public showError(message: string): void {
+    this.state = { kind: 'error', message };
+    this.status.textContent = message;
+    this.status.classList.remove('ready');
+    this.status.classList.add('error');
+  }
+
+  private handleConnect(): void {
+    const target = this.joinInput.value.trim();
+    if (!target) {
+      this.showError('Introduce una URL de WebSocket.');
+      return;
+    }
+    this.state = { kind: 'connecting', target };
+    this.status.textContent = `Connecting to ${target}...`;
+    this.status.classList.remove('ready', 'error');
+    this.connectButton.disabled = true;
+    this.joinInput.disabled = true;
+    this.callbacks.onConnect(target);
+  }
+
+  private async handleHost(): Promise<void> {
+    if (!this.bridge.isElectron) {
+      this.showError('Inicia el servidor manualmente con npm run server.');
+      return;
+    }
+
+    try {
+      const info = await this.bridge.startLocalServer();
+      this.applyHostInfo(info);
+      this.callbacks.onConnect(info.wsUrl);
+    } catch (error) {
+      this.showError(error instanceof Error ? error.message : 'No se pudo arrancar el servidor.');
+    }
+  }
+
+  private applyHostInfo(info: ServerReadyPayload): void {
+    const lanLabel = info.lanAddresses.length > 0 ? info.lanAddresses.join(', ') : 'localhost';
+    this.hostDetails.textContent = `Servidor listo en puerto ${info.port} (${lanLabel})`;
+    this.joinInput.value = info.wsUrl;
+  }
+
+  private async handleStopHost(): Promise<void> {
+    if (this.bridge.isElectron) {
+      await this.bridge.stopLocalServer();
+    }
+    this.callbacks.onDisconnect();
+    this.updateDisconnected();
+  }
+}

--- a/web/liminal-hotel/src/ui/OptionsMenu.ts
+++ b/web/liminal-hotel/src/ui/OptionsMenu.ts
@@ -1,0 +1,174 @@
+import { NetClient } from '../net/NetClient';
+
+interface OptionsMenuState {
+  micEnabled: boolean;
+  pushToTalk: boolean;
+  sensitivityDb: number;
+  ambientLevel: number;
+}
+
+const SESSION_KEY = 'liminal-hotel-options';
+
+export class OptionsMenu {
+  private root: HTMLElement;
+  private toggle: HTMLInputElement;
+  private pttToggle: HTMLInputElement;
+  private sensitivity: HTMLInputElement;
+  private calibrateButton: HTMLButtonElement;
+  private micWarning: HTMLElement;
+  private state: OptionsMenuState;
+
+  constructor(private netClient: NetClient) {
+    this.root = document.createElement('div');
+    this.root.className = 'options-menu';
+
+    this.state = this.loadState();
+
+    const micSection = document.createElement('section');
+    const heading = document.createElement('h2');
+    heading.textContent = 'Privacy';
+    micSection.appendChild(heading);
+
+    const toggleLabel = document.createElement('label');
+    toggleLabel.textContent = 'Microphone';
+    this.toggle = document.createElement('input');
+    this.toggle.type = 'checkbox';
+    this.toggle.checked = this.state.micEnabled;
+    toggleLabel.appendChild(this.toggle);
+
+    const pttLabel = document.createElement('label');
+    pttLabel.textContent = 'Push-to-Talk (V)';
+    this.pttToggle = document.createElement('input');
+    this.pttToggle.type = 'checkbox';
+    this.pttToggle.checked = this.state.pushToTalk;
+    pttLabel.appendChild(this.pttToggle);
+
+    const sensitivityLabel = document.createElement('label');
+    sensitivityLabel.textContent = 'Sensitivity (dB)';
+    this.sensitivity = document.createElement('input');
+    this.sensitivity.type = 'range';
+    this.sensitivity.min = '-90';
+    this.sensitivity.max = '-10';
+    this.sensitivity.step = '1';
+    this.sensitivity.value = String(this.state.sensitivityDb);
+    sensitivityLabel.appendChild(this.sensitivity);
+
+    this.calibrateButton = document.createElement('button');
+    this.calibrateButton.textContent = 'Calibrate';
+
+    this.micWarning = document.createElement('p');
+    this.micWarning.className = 'mic-warning';
+    this.micWarning.textContent = 'Microphone OFF';
+
+    micSection.appendChild(toggleLabel);
+    micSection.appendChild(pttLabel);
+    micSection.appendChild(sensitivityLabel);
+    micSection.appendChild(this.calibrateButton);
+    micSection.appendChild(this.micWarning);
+
+    this.root.appendChild(micSection);
+
+    this.bindEvents();
+    this.applyState();
+  }
+
+  public mount(container: HTMLElement): void {
+    container.appendChild(this.root);
+  }
+
+  private bindEvents(): void {
+    this.toggle.addEventListener('change', () => {
+      this.state.micEnabled = this.toggle.checked;
+      this.persist();
+      if (this.state.micEnabled) {
+        void this.netClient.enableMic();
+      } else {
+        this.netClient.disableMic();
+      }
+      this.updateWarning();
+    });
+
+    this.pttToggle.addEventListener('change', () => {
+      this.state.pushToTalk = this.pttToggle.checked;
+      this.netClient.setPushToTalk(this.state.pushToTalk);
+      this.persist();
+      this.updateWarning();
+    });
+
+    this.sensitivity.addEventListener('input', () => {
+      const db = Number(this.sensitivity.value);
+      this.state.sensitivityDb = db;
+      this.netClient.setSensitivity(db);
+      this.persist();
+    });
+
+    this.calibrateButton.addEventListener('click', () => {
+      void this.netClient.calibrateMic().then(() => {
+        this.state.ambientLevel = this.netClient.getAmbientLevel();
+        this.persist();
+        this.micWarning.textContent = 'Calibration complete';
+        window.setTimeout(() => this.updateWarning(), 2000);
+      });
+    });
+  }
+
+  private applyState(): void {
+    this.toggle.checked = this.state.micEnabled;
+    this.pttToggle.checked = this.state.pushToTalk;
+    this.sensitivity.value = String(this.state.sensitivityDb);
+
+    this.netClient.setPushToTalk(this.state.pushToTalk);
+    this.netClient.setSensitivity(this.state.sensitivityDb);
+    this.netClient.setAmbientLevel(this.state.ambientLevel);
+
+    if (this.state.micEnabled) {
+      void this.netClient.enableMic();
+    } else {
+      this.netClient.disableMic();
+    }
+    this.updateWarning();
+  }
+
+  private updateWarning(): void {
+    if (this.state.micEnabled) {
+      this.micWarning.textContent = this.state.pushToTalk
+        ? 'Microphone active (Push-to-Talk) – only loudness is shared'
+        : 'Microphone active – only loudness is shared';
+      this.micWarning.classList.add('active');
+    } else {
+      this.micWarning.textContent = 'Microphone OFF';
+      this.micWarning.classList.remove('active');
+    }
+  }
+
+  private loadState(): OptionsMenuState {
+    try {
+      const stored = sessionStorage.getItem(SESSION_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<OptionsMenuState>;
+        return {
+          micEnabled: parsed.micEnabled ?? false,
+          pushToTalk: parsed.pushToTalk ?? false,
+          sensitivityDb: parsed.sensitivityDb ?? -50,
+          ambientLevel: parsed.ambientLevel ?? 0,
+        };
+      }
+    } catch (error) {
+      console.warn('Failed to load options state', error);
+    }
+    return {
+      micEnabled: false,
+      pushToTalk: false,
+      sensitivityDb: -50,
+      ambientLevel: 0,
+    };
+  }
+
+  private persist(): void {
+    try {
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify(this.state));
+    } catch (error) {
+      console.warn('Failed to persist options', error);
+    }
+  }
+}

--- a/web/liminal-hotel/tsconfig.json
+++ b/web/liminal-hotel/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "lib": ["ES2020", "DOM"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*", "src/**/*.d.ts", "vite.config.ts"]
+}

--- a/web/liminal-hotel/vite.config.ts
+++ b/web/liminal-hotel/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
+  }
+});


### PR DESCRIPTION
## Summary
- convert the repo into an npm workspace monorepo with dedicated server, web client, and Electron desktop app packages plus shared scripts
- scaffold the Vite-powered web client with lobby UI, microphone HUD/options integration, and host bridging that can request a local server from Electron
- add an Electron shell that loads the client, spawns the Node server on a free port with LAN status updates, and documents the workflow and privacy controls in the README

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d82b84048c8325b1da9fe6d533e82c